### PR TITLE
Add universal dmg for macOS in release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,9 @@ jobs:
 
                - name: Rust setup
                  uses: dtolnay/rust-toolchain@stable
+                 with:
+                      # Those targets are only used on macos runners so it's in an `if` to slightly speed up windows and linux builds.
+                      targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
 
                - name: Rust cache
                  uses: swatinem/rust-cache@v2
@@ -78,3 +81,4 @@ jobs:
                       releaseBody: "See the assets to download and install this version."
                       releaseDraft: true
                       prerelease: false
+                      args: ${{ matrix.platform == 'macos-latest' && '--target universal-apple-darwin' || '' }}


### PR DESCRIPTION
Currently, the release job only builds for the architecture the GH macOS runner runs on, which seems to be aaarch64. This builds both targets and packages them into a single universal .dmg file usable for both Intel and ARM macs.

I did not touch the CI job file. As I am not very much aware how the build system works and did not want to break anything. Feel free to edit and/or add to this PR.