### PR TITLE
fix: Removed colon from password label to match username label

### DIFF
--- a/src/routes/_api/login/$userId.$userName.tsx
+++ b/src/routes/_api/login/$userId.$userName.tsx
@@ -155,12 +155,12 @@ function LoginUser() {
 						width: "100%",
 					}}
 				>
-					<InputLabel htmlFor="user-password">Password:</InputLabel>
+					<InputLabel htmlFor="user-password">Password</InputLabel>
 					<OutlinedInput
 						id="user-password"
 						type={password.showpass ? "text" : "password"}
 						onChange={handlePassword("password")}
-						label="Password:"
+						label="Password"
 						endAdornment={
 							<InputAdornment position="end">
 								<IconButton

--- a/src/routes/_api/login/manual.tsx
+++ b/src/routes/_api/login/manual.tsx
@@ -144,13 +144,13 @@ function UserLoginManual() {
 						onChange={(e) => setUsername(e.currentTarget.value)}
 					/>
 					<FormControl sx={{ width: "100%" }} variant="outlined">
-						<InputLabel htmlFor="user-password">Password:</InputLabel>
+						<InputLabel htmlFor="user-password">Password</InputLabel>
 						<OutlinedInput
 							fullWidth
 							id="user-password"
 							type={password.showpass ? "text" : "password"}
 							onChange={handlePassword("password")}
-							label="Password:"
+							label="Password"
 							endAdornment={
 								<InputAdornment position="end">
 									<IconButton


### PR DESCRIPTION
This PR removes the colon which was appended to the Password label, this is now consistent with the username as I feel it looks better without the colon.