### PR TITLE
fix: Temporary fix for Wayland protocol error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,10 @@ jobs:
                       TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
                       TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
                       TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+
+                      # TODO: Remove the below command after upstream issue is fixed
+                      # Related issue: https://github.com/tauri-apps/tauri/issues/10702
+                      WEBKIT_DISABLE_DMABUF_RENDERER: 1 # Disable DMABUF renderer on Wayland
                  with:
                       tagName: ${{ github.ref_name }} # This only works if your workflow triggers on new tags.
                       releaseName: "App Name v__VERSION__" # tauri-action replaces \_\_VERSION\_\_ with the app version.


### PR DESCRIPTION
I have been getting the following error on Wayland after some updates today:

```bash
❯ blink-player

(blink-player:19019): Gtk-WARNING **: 11:33:08.689: Theme parsing error: gtk.css:6691:68: Invalid name of pseudo-class

(WebKitWebProcess:19070): Gtk-WARNING **: 11:33:09.066: Theme parsing error: gtk.css:6691:68: Invalid name of pseudo-class
Gdk-Message: 11:33:09.285: Error 71 (Protocol error) dispatching to Wayland display.
```

After some research I found the following issue https://github.com/tauri-apps/tauri/issues/10702, which uses the following command as a workaround to it until the issue is fixed on Nvidia's side: `WEBKIT_DISABLE_DMABUF_RENDERER=1`

I have tested this on my system: `Arch Linux Hyprland + NVIDIA`, and this has worked fine for me.

In this PR I have updated the build workflow to iinclude this command in the build itself.