### PR TITLE
Improve PlayButton with Preferences and Error Handling; Fix Manual Route Param Handling

### DIFF
--- a/src/routes/_api/login/manual.tsx
+++ b/src/routes/_api/login/manual.tsx
@@ -35,7 +35,7 @@ import {
 export const Route = createFileRoute("/_api/login/manual")({
 	component: UserLoginManual,
 	validateSearch: (search): { redirect?: string } => {
-		return { redirect: String(search.redirect) };
+		return { redirect: search.redirect ? String(search.redirect) : undefined };
 	},
 });
 


### PR DESCRIPTION
This pull request introduces enhancements to the `PlayButton` component in `src/components/buttons/playButton.tsx`, focusing on user preferences for subtitles and audio, improved handling of series episodes, and better error handling. Additionally, there is a minor fix in the `manual.tsx` route to handle undefined search parameters gracefully.

### Enhancements to `PlayButton` functionality:

* **Subtitle and audio preferences support**:
  - Integrated user preferences for subtitle and audio languages by fetching the current user's configuration using `getUserApi`. The preferred subtitle and audio tracks are now selected based on these preferences, with fallbacks to default or first available options.
* **Improved handling of series episodes**:
  - Refactored the `iconOnly` condition to ensure proper handling of series episodes by dynamically determining the current episode ID. This includes disabling the button when no episodes are available or when data is still loading.
  - Updated the button label logic to display appropriate messages such as "Loading..." or "No episodes to watch found" when applicable.

* **Error handling improvements**:
  - Added checks to prevent runtime errors when accessing nested properties of `currentEpisode.data`. This includes null-safe access to properties like `Items`, `IndexNumber`, and `PlaybackPositionTicks`.

### Minor fix in `manual.tsx`:

* **Graceful handling of undefined search parameters**:
  - Updated the `validateSearch` function in `src/routes/_api/login/manual.tsx` to handle cases where `search.redirect` is undefined, ensuring the return value is either a string or `undefined` instead of throwing an error.